### PR TITLE
[WIP] try to bring back support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -26,6 +26,8 @@
   docstring linting rules (by [@cchwala](https://github.com/cchwala))
 - [PR 36](https://github.com/OpenSenseAction/poligrain/pull/36) Add API to docs
   (by [@cchwala](https://github.com/cchwala))
+- [PR 42](https://github.com/OpenSenseAction/poligrain/pull/42) Add back support
+  for Python 3.9 (by [@cchwala](https://github.com/cchwala))
 
 ### Breaking changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ report.exclude_also = [
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.10"
+python_version = "3.9"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -119,7 +119,7 @@ disallow_incomplete_defs = true
 [tool.ruff]
 src = ["src"]
 line-length = 88
-target-version = "py310"
+target-version = "py39"
 extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10, <3.12"
+python = ">=3.9, <3.12"
 
 furo = { version = ">=2023.08.17", optional = true }
 myst_parser = { version = ">=0.13", optional = true }

--- a/src/poligrain/spatial.py
+++ b/src/poligrain/spatial.py
@@ -111,8 +111,8 @@ def calc_point_to_point_distances(
     x_b, y_b = get_point_xy(ds_points_b)
 
     distance_matrix = scipy.spatial.distance_matrix(
-        x=list(zip(x_a.values, y_a.values, strict=True)),
-        y=list(zip(x_b.values, y_b.values, strict=True)),
+        x=list(zip(x_a.values, y_a.values)),
+        y=list(zip(x_b.values, y_b.values)),
     )
 
     dim_a = x_a.dims[0]
@@ -281,7 +281,7 @@ def calc_intersect_weights(
     # Iterate only over the indices within the bounding box and
     # calculate the intersect weigh for each pixel
     ix_in_bbox = np.where(bounding_box == True)  # noqa: E712 # pylint: disable=C0121
-    for i, j in zip(ix_in_bbox[0], ix_in_bbox[1], strict=False):
+    for i, j in zip(ix_in_bbox[0], ix_in_bbox[1]):
         pixel_poly = Polygon(
             [
                 grid_corners.ll_grid[i, j],

--- a/src/poligrain/xarray.py
+++ b/src/poligrain/xarray.py
@@ -1,4 +1,5 @@
 """xarray Accessors."""
+from __future__ import annotations
 
 import matplotlib.axes
 import xarray as xr

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -32,7 +32,7 @@ class TestSparseIntersectWeights(unittest.TestCase):
         )
 
         for x1, y1, x2, y2, cml_id in zip(
-            x1_list, y1_list, x2_list, y2_list, cml_id_list, strict=False
+            x1_list, y1_list, x2_list, y2_list, cml_id_list
         ):
             expected = plg.spatial.calc_intersect_weights(
                 x1_line=x1,


### PR DESCRIPTION
We can support Python 3.9 by just dropping some minor things like `zip(... ,strict=True) and using `from __future__ import annotations`.

We should do that because`pycomlink` requires `tensorflow` and this is currently only available for Python <= 3.9 on Windows.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks from pre-commit passed
- [ ] Added an entry in the CHANGELOG.md file
