### PR TITLE
[just for testing] investigate nbmake error in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ change.
 Checkout the [docs](https://poligrain.readthedocs.io/en/latest/index.html) to
 explore the package. The examples can also be run as notebooks locally.
 
+Bla
+
 <!-- prettier-ignore-start -->
 [actions-badge]:            https://github.com/OpenSenseAction/poligrain/workflows/CI/badge.svg
 [actions-link]:             https://github.com/OpenSenseAction/poligrain/actions


### PR DESCRIPTION
Currently some CI runs fail with 
```
=================================== FAILURES ===================================
_____ /home/runner/work/poligrain/poligrain/docs/notebooks/Plotting.ipynb ______
NBMAKE INTERNAL ERROR
Exception ignored in: <socket.socket fd=-1, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
```

See e.g. https://github.com/OpenSenseAction/poligrain/actions/runs/9502701241/job/26288875441?pr=41

As far as I can tell there is no change in our repo that causes this, but I could also not find open issues on this in other repos. Hence, this PR is meant to investigate this problem. If we find that we cannot fix the problem, we might just disable nbmake for the plattforms were it currently fails.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks from pre-commit passed
- [ ] Added an entry in the CHANGELOG.md file
