### PR TITLE
fix deprecation warning in pyproj transformer.transform

### DIFF
--- a/src/poligrain/spatial.py
+++ b/src/poligrain/spatial.py
@@ -84,6 +84,7 @@ def project_point_coordinates(
     transformer = pyproj.Transformer.from_crs(
         crs_to=target_projection, crs_from=source_projection, always_xy=True
     )
+    # the line below should raise a deprecation waring
     x_projected, y_projected = transformer.transform(x, y)  # pylint: disable=unpacking-non-sequence
 
     x_projected = xr.DataArray(data=x_projected, coords=x.coords, name="x")


### PR DESCRIPTION
UPDATE: We currently ignore deprecation warning in `poligrain` via config in pyproject.toml. Hence, I close this issue, but we should check for these warning in the future...

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks from pre-commit passed
- [ ] Added an entry in the CHANGELOG.md file

The following line in poligrain/spatial.py:87: in project_point_coordinates
```
x_projected, y_projected = transformer.transform(x, y) 
```

did raise this error

```python
E  DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```
