### PR TITLE
add back support for Python 3.9, again...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Breaking changes
 
+## v0.2.2
+
+Add back support for Python 3.9.
+
 ## v0.2.1
 
 This is just a quick release to start tracking via zenodo to get a DOI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10, <4.0.0"
+python = ">=3.9, <4.0.0"
 # main package dependencies
 netcdf4 = ">=1.6.5"
 xarray = ">=2023.12.0"


### PR DESCRIPTION
Since there does not seem to have been a very concrete reason to remove support for Python 3.9, except for the fact that all major packages dropped it this year, we are adding it back to make life easier for some people that still depend on 3.9.

- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks from pre-commit passed
- [x] Added an entry in the CHANGELOG.md file
