### PR TITLE
Fix GridAtLines to not return `time` in coords when pasing data witout time dim

### DIFF
--- a/docs/development/CHANGELOG.md
+++ b/docs/development/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ### Bug fixes
 
+- [PR96](https:github.com/OpenSenseAction/poligrain/pull/96) fix problem of
+  GridAtLines which returned `time` in coords when passing data without time
+  dimension (by [@cchwala](https://github.com/cchwala))
+
 ### Maintenance
 
 ### Breaking changes

--- a/src/poligrain/spatial.py
+++ b/src/poligrain/spatial.py
@@ -336,6 +336,7 @@ class GridAtLines:
 
         if time_dim_was_expanded:
             gridded_data_along_line = gridded_data_along_line.isel(time=0)
+            gridded_data_along_line = gridded_data_along_line.drop_vars("time")
         return gridded_data_along_line
 
 

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -205,6 +205,12 @@ def test_GridAtLines():
         da_expected_time_series.isel(time=0).data,
     )
 
+    # Make sure that `time` is not in coords here because we pass data
+    # without a time stamp. Internally `expand_dims('time')` is used
+    # and we do `.isel(time=0)` when returning data. This is not enough,
+    # though. This led to unexpected behavior.
+    assert "time" not in radar_along_cml.coords
+
 
 # Copy-paste test from wradlib for the associated copied wradlib function
 def test__get_statfunc():


### PR DESCRIPTION

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks from pre-commit passed
- [x] Added an entry in the CHANGELOG.md file
