### PR TITLE
revert to windows-latest in CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-2022]
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
In #109 we did set `windows-2022` in the ci config because of strange errors in CI. This PR is here to set it back to `windows-latest`, assuming that the errors are cause by some config problems on the side of Github with the windows runners...

We should just rerun CI from time to time to check.